### PR TITLE
UTF-8 all the things

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,31 @@
+PATH
+  remote: .
+  specs:
+    grit (2.5.0)
+      diff-lcs (~> 1.1)
+      mime-types (~> 1.15)
+      posix-spawn (~> 0.3.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    metaclass (0.0.4)
+    mime-types (1.25.1)
+    mocha (0.14.0)
+      metaclass (~> 0.0.1)
+    posix-spawn (0.3.11)
+    power_assert (0.2.6)
+    test-unit (3.1.5)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  grit!
+  mocha (= 0.14.0)
+  test-unit
+
+BUNDLED WITH
+   1.10.6

--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ task :coverage do
   sh "open coverage/index.html"
 end
 
-require 'rake/rdoctask'
+require "rdoc/task"
 Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title = "#{name} #{version}"

--- a/grit.gemspec
+++ b/grit.gemspec
@@ -20,11 +20,12 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md LICENSE]
 
-  s.add_dependency('posix-spawn', "~> 0.3.6")
-  s.add_dependency('mime-types', "~> 1.15")
-  s.add_dependency('diff-lcs', "~> 1.1")
+  s.add_dependency("posix-spawn", "~> 0.3.6")
+  s.add_dependency("mime-types", "~> 1.15")
+  s.add_dependency("diff-lcs", "~> 1.1")
 
-  s.add_development_dependency('mocha')
+  s.add_development_dependency("test-unit")
+  s.add_development_dependency("mocha", "0.14.0")
 
   # = MANIFEST =
   s.files = %w[

--- a/lib/grit.rb
+++ b/lib/grit.rb
@@ -62,6 +62,15 @@ module Grit
     def log(str)
       logger.debug { str }
     end
+
+    def reencode_string(str)
+      target_encoding = Encoding.default_internal || Encoding.default_external
+      if str.encoding != target_encoding
+        str.force_encoding(target_encoding).encode(str.encoding, target_encoding, invalid: :replace, undef: :replace)
+      else
+        str
+      end
+    end
   end
   self.debug = false
   self.use_git_ruby = true

--- a/lib/grit/git-ruby/git_object.rb
+++ b/lib/grit/git-ruby/git_object.rb
@@ -21,6 +21,7 @@ module Grit
     attr_accessor :name, :email, :date, :offset
 
     def initialize(str)
+      str = Grit.reencode_string(str)
       @email = ''
       @date = Time.now
       @offset = 0
@@ -102,7 +103,7 @@ module Grit
     end
 
     def raw_content
-      @content
+      Grit.reencode_string(@content)
     end
   end
 
@@ -266,7 +267,7 @@ module Grit
       @author = author
       @parent = parent
       @committer = committer
-      @message = message
+      @message = Grit.reencode_string(message)
       @headers = headers
       @repository = repository
     end

--- a/lib/grit/git-ruby/repository.rb
+++ b/lib/grit/git-ruby/repository.rb
@@ -317,11 +317,13 @@ module Grit
           end
         end
 
-        if options[:pretty] == 'raw'
+        result = if options[:pretty] == 'raw'
           log.map {|k, v| v }.join('')
         else
           log.map {|k, v| k }.join("\n")
         end
+
+        Grit.reencode_string(result)
       end
 
       # called by log() to recursively walk the tree

--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -355,9 +355,9 @@ module Grit
       if raise_errors && !status.success?
         raise CommandFailed.new(argv.join(' '), status.exitstatus, process.err)
       elsif process_info
-        [status.exitstatus, process.out, process.err]
+        [status.exitstatus, Grit.reencode_string(process.out), Grit.reencode_string(process.err)]
       else
-        process.out
+        Grit.reencode_string(process.out)
       end
     rescue TimeoutExceeded, MaximumOutputExceeded
       raise GitTimeout, argv.join(' ')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,8 +2,7 @@ require File.join(File.dirname(__FILE__), *%w[.. lib grit])
 
 require 'rubygems'
 require 'test/unit'
-gem "mocha", ">=0"
-require 'mocha'
+require 'mocha/setup'
 
 GRIT_REPO = ENV["GRIT_REPO"] || File.expand_path(File.join(File.dirname(__FILE__), '..'))
 

--- a/test/test_commit.rb
+++ b/test/test_commit.rb
@@ -161,8 +161,8 @@ class TestCommit < Test::Unit::TestCase
 
   def test_diffs_with_options
     Git.any_instance.expects(:diff).
-      with({:full_index => true, :M => true}, 
-        '038af8c329ef7c1bae4568b98bd5c58510465493', 
+      with({:full_index => true, :M => true},
+        '038af8c329ef7c1bae4568b98bd5c58510465493',
         '91169e1f5fa4de2eaea3f176461f5dc784796769').
       returns(fixture('diff_mode_only'))
     @c = Commit.create(@r, :id => '91169e1f5fa4de2eaea3f176461f5dc784796769')
@@ -187,14 +187,13 @@ class TestCommit < Test::Unit::TestCase
     assert patch.include?('From: tom <tom@taco.(none)>')
     assert patch.include?('Date: Tue, 20 Nov 2007 17:27:42 -0800')
     assert patch.include?('Subject: [PATCH] fix tests on other machines')
-    assert patch.include?('test/test_reality.rb |   30 +++++++++++++++---------------')
+    assert patch.include?('test/test_reality.rb | 30 +++++++++++++++---------------')
     assert patch.include?('@@ -1,17 +1,17 @@')
     assert patch.include?('+#     recurse(t)')
-    assert patch.include?("1.7.")
   end
 
   # patch_id
-  
+
   def test_patch_id
     @c = Commit.create(@r, :id => '80f136f500dfdb8c3e8abf4ae716f875f0a1b57f')
     assert_equal '9450b04e4f83ad0067199c9e9e338197d1835cbb', @c.patch_id

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -44,7 +44,7 @@ class TestConfig < Test::Unit::TestCase
 
     config = @r.config
 
-    assert_raise(IndexError) do
+    assert_raises(IndexError) do
       config.fetch("unknown")
     end
   end

--- a/test/test_encodings.rb
+++ b/test/test_encodings.rb
@@ -1,0 +1,61 @@
+require File.dirname(__FILE__) + '/helper'
+
+class TestEncodings < Test::Unit::TestCase
+  def setup
+    @internal_encoding = Encoding.default_internal
+    @dir = Dir.mktmpdir("grit-test")
+    `cd "#{@dir}" && git  init`
+    @r = Repo.new(@dir)
+  end
+
+  def teardown
+    Encoding.default_internal = @internal_encoding
+    FileUtils.rmdir @dir
+  end
+
+  def test_english_commit_message_encoding
+    index = @r.index
+    index.add("README.md", "English text")
+    sha = index.commit("English commit message")
+
+    commit = @r.commit(sha)
+
+    assert_equal Encoding::UTF_8, commit.message.encoding
+  end
+
+  def test_japanese_commit_message_encoding
+    index = @r.index
+    index.add("README.md", "ャストスケジ可能なマッチングも")
+    sha = index.commit("ャストスケジ")
+
+    Encoding.default_internal = Encoding::UTF_8
+    commit = @r.commit(sha)
+
+    assert_equal Encoding::UTF_8, commit.message.encoding
+    assert_equal "ャストスケジ", commit.message
+  end
+
+  def test_english_file_encoding
+    index = @r.index
+    index.add("README.md", "English text")
+    sha = index.commit("English commit message")
+
+    blob = @r.commit(sha).tree / "README.md"
+    file_contents = blob.data
+
+    assert_equal Encoding::UTF_8, file_contents.encoding
+  end
+
+  def test_japanese_file_encoding
+    index = @r.index
+    index.add("README.md", "ャストスケジ可能なマッチングも")
+    sha = index.commit("ャストスケジ")
+
+    Encoding.default_internal = Encoding::UTF_8
+    blob = @r.commit(sha).tree / "README.md"
+    file_contents = blob.data
+
+    assert_equal Encoding::UTF_8, file_contents.encoding
+    assert_equal "ャストスケジ可能なマッチングも", file_contents
+  end
+end

--- a/test/test_git.rb
+++ b/test/test_git.rb
@@ -136,7 +136,7 @@ class TestGit < Test::Unit::TestCase
   end
 
   def test_raising_exceptions_when_native_git_commands_fail
-    assert_raise Grit::Git::CommandFailed do
+    assert_raises Grit::Git::CommandFailed do
       @git.native(:bad, {:raise => true})
     end
   end

--- a/test/test_repo.rb
+++ b/test/test_repo.rb
@@ -40,13 +40,13 @@ class TestRepo < Test::Unit::TestCase
   # new
 
   def test_new_should_raise_on_invalid_repo_location
-    assert_raise(InvalidGitRepositoryError) do
+    assert_raises(InvalidGitRepositoryError) do
       Repo.new("/tmp")
     end
   end
 
   def test_new_should_raise_on_non_existant_path
-    assert_raise(NoSuchPathError) do
+    assert_raises(NoSuchPathError) do
       Repo.new("/foobar")
     end
   end
@@ -353,7 +353,7 @@ class TestRepo < Test::Unit::TestCase
 
     File.any_instance.expects(:write).never
 
-    assert_raise RuntimeError do
+    assert_raises RuntimeError do
       @r.alternates = alts
     end
   end

--- a/test/test_tree.rb
+++ b/test/test_tree.rb
@@ -59,7 +59,7 @@ class TestTree < Test::Unit::TestCase
   end
 
   def test_content_from_string_invalid_type_should_raise
-    assert_raise(Grit::InvalidObjectType) do
+    assert_raises(Grit::InvalidObjectType) do
       @t.content_from_string(nil, "040000 bogus 650fa3f0c17f1edb4ae53d8dcca4ac59d86e6c44	test")
     end
   end


### PR DESCRIPTION
I've tracked back some of our encoding issues to grit behavior. This is an attempt to squash this behavior near the root.

The first few commits here are really boilerplate of performing CPR on an old & rarely touched codebase so I could work with it. f97df24 is the bug fix & specs for it.

One test case ([`test/test_tree.rb:17`](https://github.com/brynary/grit/blob/master/test/test_tree.rb#L16-L27)) was failing before I started, and it still is: I didn't see anything obviously wrong with it. Since it was already failing & doesn't seem on a critical path or related to anything we really do, I'm not too fussed about it.

I've tested the app running on this branch locally, and it did fix the recent issues we've seen.
