### PR TITLE
Force encoding in other places

### DIFF
--- a/lib/grit.rb
+++ b/lib/grit.rb
@@ -65,7 +65,7 @@ module Grit
 
     def reencode_string(str)
       target_encoding = Encoding.default_internal || Encoding.default_external
-      if str.encoding != target_encoding
+      if str && str.encoding != target_encoding
         str.force_encoding(target_encoding).encode(str.encoding, target_encoding, invalid: :replace, undef: :replace)
       else
         str

--- a/lib/grit/commit.rb
+++ b/lib/grit/commit.rb
@@ -137,7 +137,7 @@ module Grit
     # - it broke when 'encoding' was introduced - not sure what else might show up
     #
     def self.list_from_string(repo, text)
-      lines = text.split("\n")
+      lines = Grit.reencode_string(text).split("\n")
 
       commits = []
 

--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -322,7 +322,7 @@ module Grit
 
       # fall back to using a shell when the last argument looks like it wants to
       # start a pipeline for compatibility with previous versions of grit.
-      return run(prefix, cmd, '', options, args) if args[-1].to_s[0] == ?|
+      return Grit.reencode_string(run(prefix, cmd, '', options, args)) if args[-1].to_s[0] == ?|
 
       # more options
       input    = options.delete(:input)


### PR DESCRIPTION
- missed an early return for `Grit#native` that needed the call
- Commit#list_from_string can be called with arbitrary text that didn't
  originate from within `Grit`, so it should be sanitized.
