### PR TITLE
Allow providing timeouts

### DIFF
--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -341,11 +341,18 @@ module Grit
       # run it and deal with fallout
       Grit.log(argv.join(' ')) if Grit.debug
 
+      resolved_timeout =
+        case timeout
+        when true then Grit::Git.git_timeout
+        when Numeric then timeout
+        else nil
+        end
+
       process =
         Child.new(env, *(argv + [{
           :input   => input,
           :chdir   => chdir,
-          :timeout => (Grit::Git.git_timeout if timeout == true),
+          :timeout => resolved_timeout,
           :max     => (Grit::Git.git_max_size if timeout == true)
         }]))
       Grit.log(process.out) if Grit.debug


### PR DESCRIPTION
by my reading of the inline documentation, this is how the code is
supposed to behave. This is how we've been assuming it behaves, as well.
But it totally doesn't! We provide a numeric timeout, and then:

1. we assign the value to a `timeout` local variable
2. we do: `(Grit::Git.git_timeout if timeout == true)`
3. this evaluates to nil...
4. we _could_ alternatively use the `with_timeout` method, but I don't
   want to, because it makes it harder for us to mix-and-match git
   clients. It's nice to assume that all of our git clients take a
   timeout attribute.

Context: when the inline-documentation was written, it was possible to pass a numeric value (https://github.com/brynary/grit/commit/1cfcc1b8023fbddd983d585a71f1ec33b307f0d4)