### PR TITLE
Include process STDOUT in CommandFailed exception message

### DIFF
--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -23,15 +23,20 @@ module Grit
       # The integer exit status.
       attr_reader :exitstatus
 
+      # Everything output on the command's stdout as a String.
+      attr_reader :out
+
       # Everything output on the command's stderr as a String.
       attr_reader :err
 
-      def initialize(command, exitstatus=nil, err='')
+      def initialize(command, exitstatus=nil, out='', err='')
         if exitstatus
           @command = command
           @exitstatus = exitstatus
+          @out = out
           @err = err
           message = "Command failed [#{exitstatus}]: #{command}"
+          message << "\n\n" << out unless out.nil? || out.empty?
           message << "\n\n" << err unless err.nil? || err.empty?
           super message
         else
@@ -360,7 +365,7 @@ module Grit
 
       status = process.status
       if raise_errors && !status.success?
-        raise CommandFailed.new(argv.join(' '), status.exitstatus, process.err)
+        raise CommandFailed.new(argv.join(' '), status.exitstatus, process.out, process.err)
       elsif process_info
         [status.exitstatus, Grit.reencode_string(process.out), Grit.reencode_string(process.err)]
       else


### PR DESCRIPTION
When a native git command fails, having the `STDOUT` in addition to the `STDERR` might help diagnose the problem, especially if the `STDERR` is empty.

Specifically, we've seen cases where `git fetch` invocations exit non-zero with no `STDERR` reported within the exception message.